### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cy6erskunk/fencing-score/security/code-scanning/3](https://github.com/cy6erskunk/fencing-score/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/CI.yml` so the workflow documents and enforces least privilege regardless of repository/org defaults.

Best fix here (without changing intended functionality): add:

```yml
permissions:
  contents: read
```

directly under the `on:` trigger block (before `jobs:`). This applies to all jobs in this workflow, including `test`. No imports, methods, or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
